### PR TITLE
Reviewer/issue/#85

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -5,6 +5,7 @@ import { DevDBConfig } from './config/db.config';
 import { UsersModule } from './users/users.module';
 import { ReviewsModule } from './reviews/reviews.module';
 import { BookModule } from './book/book.module';
+import { ReviewerModule } from './reviewer/reviewer.module';
 
 @Module({
   imports: [
@@ -13,7 +14,7 @@ import { BookModule } from './book/book.module';
       type: 'mysql',
       entities: [__dirname + 'entities/*.entity.ts'],
       autoLoadEntities: true,
-      synchronize: false, //서버 처음에 켤 때 true고 그 이후론 false로 하는 듯
+      synchronize: true, //서버 처음에 켤 때 true고 그 이후론 false로 하는 듯
     }),
     ConfigModule.forRoot({
       //process.env 전역에서 사용가능?
@@ -22,6 +23,7 @@ import { BookModule } from './book/book.module';
     UsersModule,
     ReviewsModule,
     BookModule,
+    ReviewerModule,
   ],
 })
 export class AppModule {}

--- a/server/src/book/book.controller.ts
+++ b/server/src/book/book.controller.ts
@@ -6,7 +6,7 @@ export class BookController {
   constructor(private bookService: BookService) {}
 
   //쿼리? 파라미터?
-  @Get('/search/')
+  @Get('/search')
   search(@Query() query, @Res() res) {
     return this.bookService.getBooks(query).then((value) => {
       res.status(HttpStatus.OK).json({

--- a/server/src/entities/comment.entity.ts
+++ b/server/src/entities/comment.entity.ts
@@ -27,9 +27,9 @@ export class Comment {
   @DeleteDateColumn()
   deleteAt: Date;
 
-  @ManyToOne(() => User, (user) => user.comments)
+  @ManyToOne(() => User, (user) => user.comments, { onDelete: 'SET NULL' })
   user: User;
 
-  @ManyToOne(() => Review, (review) => review.comments)
+  @ManyToOne(() => Review, (review) => review.comments, { onDelete: 'CASCADE' })
   review: Review;
 }

--- a/server/src/entities/like.entity.ts
+++ b/server/src/entities/like.entity.ts
@@ -8,9 +8,9 @@ export class Like {
   id: number;
 
   //어떤 유저가 어떤 리뷰에 좋아요를 눌렀는지
-  @ManyToOne(() => User, (user) => user.likes)
+  @ManyToOne(() => User, (user) => user.likes, { onDelete: 'CASCADE' })
   user: User;
 
-  @ManyToOne(() => Review, (review) => review.likes)
+  @ManyToOne(() => Review, (review) => review.likes, { onDelete: 'CASCADE' })
   review: Review;
 }

--- a/server/src/entities/review.entity.ts
+++ b/server/src/entities/review.entity.ts
@@ -58,16 +58,16 @@ export class Review {
   updatedAt: Date;
 
   //writer: userId가 FK로 저장됨
-  @ManyToOne(() => User, (user) => user.reviews)
+  @ManyToOne(() => User, (user) => user.reviews, { onDelete: 'SET NULL' })
   user: User;
 
-  @OneToMany(() => Comment, (comment) => comment.review, { cascade: true })
+  @OneToMany(() => Comment, (comment) => comment.review)
   comments: Comment[];
 
-  @OneToMany(() => Like, (like) => like.review, { cascade: true })
+  @OneToMany(() => Like, (like) => like.review)
   likes: Like[];
 
-  @ManyToMany(() => Tag)
+  @ManyToMany(() => Tag, { cascade: true })
   @JoinTable({
     name: 'review_tags',
     joinColumn: {

--- a/server/src/entities/review.entity.ts
+++ b/server/src/entities/review.entity.ts
@@ -38,10 +38,6 @@ export class Review {
   @Column('float', { name: 'score', default: 0 })
   score: number;
 
-  //book cover
-  @Column('varchar', { name: 'cover_img' })
-  coverImg: string;
-
   // 조회수
   @Column('int', { name: 'view_count', default: 0 })
   view_count: number;

--- a/server/src/entities/review.entity.ts
+++ b/server/src/entities/review.entity.ts
@@ -19,6 +19,9 @@ export class Review {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column('varchar', { name: 'isbn', length: 13 })
+  isbn: string;
+
   // 내용
   @Column('varchar', { name: 'text' })
   text: string;

--- a/server/src/entities/user.entity.ts
+++ b/server/src/entities/user.entity.ts
@@ -53,9 +53,11 @@ export class User {
   @OneToMany(() => Like, (like) => like.user)
   likes: Like[];
 
+  //팔로워 수 카운트
   @Column('int', { default: 0 })
   countFollower: number;
 
+  //팔로잉 수 카운트
   @Column('int', { default: 0 })
   countFollowing: number;
 

--- a/server/src/entities/user.entity.ts
+++ b/server/src/entities/user.entity.ts
@@ -53,14 +53,6 @@ export class User {
   @OneToMany(() => Like, (like) => like.user)
   likes: Like[];
 
-  //팔로워 수 카운트
-  @Column('int', { default: 0 })
-  countFollower: number;
-
-  //팔로잉 수 카운트
-  @Column('int', { default: 0 })
-  countFollowing: number;
-
   @ManyToMany(() => User, { cascade: true })
   @JoinTable({
     name: 'following',

--- a/server/src/entities/user.entity.ts
+++ b/server/src/entities/user.entity.ts
@@ -53,15 +53,21 @@ export class User {
   @OneToMany(() => Like, (like) => like.user)
   likes: Like[];
 
+  @Column('int', { default: 0 })
+  countFollower: number;
+
+  @Column('int', { default: 0 })
+  countFollowing: number;
+
   @ManyToMany(() => User, { cascade: true })
   @JoinTable({
     name: 'following',
     joinColumn: {
-      name: 'following',
+      name: 'userId',
       referencedColumnName: 'id',
     },
     inverseJoinColumn: {
-      name: 'userId',
+      name: 'following',
       referencedColumnName: 'id',
     },
   })
@@ -71,11 +77,11 @@ export class User {
   @JoinTable({
     name: 'follower',
     joinColumn: {
-      name: 'follower',
+      name: 'userId',
       referencedColumnName: 'id',
     },
     inverseJoinColumn: {
-      name: 'userId',
+      name: 'follower',
       referencedColumnName: 'id',
     },
   })

--- a/server/src/reviewer/reviewer.controller.ts
+++ b/server/src/reviewer/reviewer.controller.ts
@@ -1,16 +1,26 @@
-import { Controller, Get, HttpStatus, Param, Res } from '@nestjs/common';
+import { Controller, Get, HttpStatus, Param, Post, Res } from '@nestjs/common';
 import { ReviewerService } from './reviewer.service';
 
 @Controller('api/reviewer')
 export class ReviewerController {
   constructor(private reviewerService: ReviewerService) {}
 
+  @Get('/detail/:nickname')
+  getReviwerDetail(@Param('nickname') nickname: string, @Res() res){
+    return this.reviewerService.reviewerDetail(nickname).then((value)=> {
+      res.status(HttpStatus.OK).json({
+        success: true,
+        reviewer: value,
+      });
+    });
+  }
+
   @Get('/:genres')
   getReviewers(@Param('genres') genres: string, @Res() res) {
     return this.reviewerService.getReviewer(genres).then((value) => {
       res.status(HttpStatus.OK).json({
         success: true,
-        reviewer: value,
+        reviewers: value,
       });
     });
   }

--- a/server/src/reviewer/reviewer.controller.ts
+++ b/server/src/reviewer/reviewer.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, HttpStatus, Param, Res } from '@nestjs/common';
+import { ReviewerService } from './reviewer.service';
+
+@Controller('api/reviewer')
+export class ReviewerController {
+  constructor(private reviewerService: ReviewerService) {}
+
+  @Get('/:genres')
+  getReviewers(@Param('genres') genres: string, @Res() res) {
+    return this.reviewerService.getReviewer(genres).then((value) => {
+      res.status(HttpStatus.OK).json({
+        success: true,
+        reviewer: value,
+      });
+    });
+  }
+}

--- a/server/src/reviewer/reviewer.controller.ts
+++ b/server/src/reviewer/reviewer.controller.ts
@@ -6,8 +6,8 @@ export class ReviewerController {
   constructor(private reviewerService: ReviewerService) {}
 
   @Get('/detail/:nickname')
-  getReviwerDetail(@Param('nickname') nickname: string, @Res() res){
-    return this.reviewerService.reviewerDetail(nickname).then((value)=> {
+  getReviwerDetail(@Param('nickname') nickname: string, @Res() res) {
+    return this.reviewerService.reviewerDetail(nickname).then((value) => {
       res.status(HttpStatus.OK).json({
         success: true,
         reviewer: value,

--- a/server/src/reviewer/reviewer.module.ts
+++ b/server/src/reviewer/reviewer.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ReviewerService } from './reviewer.service';
+import { ReviewerController } from './reviewer.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from 'src/entities/user.entity';
+import { Review } from 'src/entities/review.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User, Review])],
+  providers: [ReviewerService],
+  controllers: [ReviewerController],
+})
+export class ReviewerModule {}

--- a/server/src/reviewer/reviewer.service.ts
+++ b/server/src/reviewer/reviewer.service.ts
@@ -14,7 +14,7 @@ export class ReviewerService {
     private reviewRepository: Repository<Review>
   ) {}
 
-  //reviewer page
+  //param과 맞는 장르를 가진 리뷰어를 불러옴
   async getReviewer(genre: string): Promise<any> {
     // , = %2C 공백은 +
     const reviewer = await this.userRepository.findAndCount({
@@ -60,10 +60,9 @@ export class ReviewerService {
 
     reviewer['reviews'].map((value, index) => {
       value['book_info'] = JSON.parse(value['book_info']);
-      delete value['createdAt'];
-      delete value['updatedAt'];
-      delete value['view_count'];
-      delete value['isPublic'];
+      ['createdAt', 'updatedAt', 'view_count', 'isPublic'].forEach(
+        (item) => delete value[item]
+      );
     });
 
     reviewer['countUserReviews'] = reviewer['reviews'].length;

--- a/server/src/reviewer/reviewer.service.ts
+++ b/server/src/reviewer/reviewer.service.ts
@@ -54,6 +54,8 @@ export class ReviewerService {
       relations: ['reviews', 'reviews.tags', 'followers', 'followings'],
     });
 
+    if (reviewer === undefined) return 'User not found';
+
     reviewer['reviews'] = reviewer['reviews'].filter(
       (review) => review.isPublic === true
     );

--- a/server/src/reviewer/reviewer.service.ts
+++ b/server/src/reviewer/reviewer.service.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { count } from 'console';
 import { Review } from 'src/entities/review.entity';
 import { User } from 'src/entities/user.entity';
-import { getRepository, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class ReviewerService {
@@ -58,7 +57,7 @@ export class ReviewerService {
       (review) => review.isPublic === true
     );
 
-    reviewer['reviews'].map((value, index) => {
+    reviewer['reviews'].map((value) => {
       value['book_info'] = JSON.parse(value['book_info']);
       ['createdAt', 'updatedAt', 'view_count', 'isPublic'].forEach(
         (item) => delete value[item]

--- a/server/src/reviewer/reviewer.service.ts
+++ b/server/src/reviewer/reviewer.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { count } from 'console';
+import { Review } from 'src/entities/review.entity';
+import { User } from 'src/entities/user.entity';
+import { getRepository, Repository } from 'typeorm';
+
+@Injectable()
+export class ReviewerService {
+  constructor(
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+    @InjectRepository(Review)
+    private reviewRepository: Repository<Review>
+  ) {}
+
+  //reviewer page
+  async getReviewer(genre: string): Promise<any> {
+    // , = %2C 공백은 +
+    const decodedgenre = decodeURIComponent(genre);
+    const r = await this.userRepository.findOne({
+      select: ['id', 'nickname'],
+      where: { genres: decodedgenre },
+      relations: ['followers'],
+    });
+    console.log(r, ' ', r['followers'].length);
+    const qb = await getRepository(User).createQueryBuilder('user');
+    const reviewer = await qb
+      .where('user.genres = :genres', { genres: genre })
+      .select('user.nickname')
+      .innerJoinAndSelect('user.followers', 'user_following_user')
+      .andWhere(
+        'user.id' + qb.subQuery().addSelect('COUNT(user.followers)', 'count')
+      )
+      //.addSelect('COUNT(user.followers)')
+      .getMany();
+    /*const reviewer = await getRepository(User)
+      .createQueryBuilder('user')
+      .where('user.genres = :genres', { genres: genre })
+      .select('user.nickname')
+      .getMany();*/
+    /*({
+      order: {
+        subQuery.followers: 'DESC',
+        createdAt: 'DESC',
+      },
+      select: ['genres', 'id', 'nickname', 'info'],
+      where: { genres: genre },
+      skip: 0,
+      take: 2,
+    });*/
+    console.log(reviewer);
+    //return reviewer;
+  }
+}

--- a/server/src/reviewer/reviewer.service.ts
+++ b/server/src/reviewer/reviewer.service.ts
@@ -31,6 +31,7 @@ export class ReviewerService {
       const tempArray = value['reviews'].filter(
         (review) => review.isPublic === true
       );
+      //리뷰수, 팔로우 수 카운트 후 본래 배열 제거
       value['countUserReview'] = tempArray.length;
       value['countFollowers'] = value['followers'].length;
       delete value['reviews'];
@@ -57,20 +58,27 @@ export class ReviewerService {
       (review) => review.isPublic === true
     );
 
-    reviewer['reviews'].map((value) => {
-      value['book_info'] = JSON.parse(value['book_info']);
-      ['createdAt', 'updatedAt', 'view_count', 'isPublic'].forEach(
-        (item) => delete value[item]
-      );
-    });
-
+    //리뷰수, 팔로, 팔로잉수 카운트 후 followers, followings 제거
     reviewer['countUserReviews'] = reviewer['reviews'].length;
     reviewer['countFollowers'] = reviewer['followers'].length;
     reviewer['countFollowings'] = reviewer['followings'].length;
     delete reviewer['followers'];
     delete reviewer['followings'];
 
-    console.log(reviewer);
+    reviewer['reviews'].map((value) => {
+      const bookInfo = JSON.parse(value['book_info']);
+      value['bookTitle'] = bookInfo['title'];
+      value['bookCover'] = bookInfo['cover'];
+      [
+        'createdAt',
+        'updatedAt',
+        'view_count',
+        'isPublic',
+        'book_info',
+        'text',
+      ].forEach((item) => delete value[item]);
+    });
+
     return reviewer;
   }
 }

--- a/server/src/reviewer/reviewer.service.ts
+++ b/server/src/reviewer/reviewer.service.ts
@@ -27,17 +27,52 @@ export class ReviewerService {
       take: 9,
     });
 
+    //review는 isPublic===true인것만 카운트함
     reviewer[0].map((value) => {
-      value['countUserReviews'] = value['reviews'].length;
+      const tempArray = value['reviews'].filter(
+        (review) => review.isPublic === true
+      );
+      value['countUserReview'] = tempArray.length;
       value['countFollowers'] = value['followers'].length;
       delete value['reviews'];
       delete value['followers'];
     });
 
+    //팔로우 수 내림차순으로 정렬
     reviewer[0].sort((a, b) => {
       return b['countFollowers'] - a['countFollowers'];
     });
 
     return reviewer[0];
+  }
+
+  //reviewer detail page
+  async reviewerDetail(nickname: string): Promise<any> {
+    const reviewer = await this.userRepository.findOne({
+      where: { nickname },
+      select: ['id', 'nickname', 'genres', 'info'],
+      relations: ['reviews', 'reviews.tags', 'followers', 'followings'],
+    });
+
+    reviewer['reviews'] = reviewer['reviews'].filter(
+      (review) => review.isPublic === true
+    );
+
+    reviewer['reviews'].map((value, index) => {
+      value['book_info'] = JSON.parse(value['book_info']);
+      delete value['createdAt'];
+      delete value['updatedAt'];
+      delete value['view_count'];
+      delete value['isPublic'];
+    });
+
+    reviewer['countUserReviews'] = reviewer['reviews'].length;
+    reviewer['countFollowers'] = reviewer['followers'].length;
+    reviewer['countFollowings'] = reviewer['followings'].length;
+    delete reviewer['followers'];
+    delete reviewer['followings'];
+
+    console.log(reviewer);
+    return reviewer;
   }
 }

--- a/server/src/reviews/dto/create-review.dto.ts
+++ b/server/src/reviews/dto/create-review.dto.ts
@@ -18,7 +18,4 @@ export class CreateReviewDto {
 
   @IsString()
   readonly tag: string;
-
-  @IsString()
-  readonly coverImg: string;
 }

--- a/server/src/reviews/reviews.controller.ts
+++ b/server/src/reviews/reviews.controller.ts
@@ -105,7 +105,7 @@ export class ReviewsController {
     return this.reviewService.loadReviews(orderby).then((value) => {
       res.status(HttpStatus.OK).json({
         success: true,
-        review: value,
+        reviews: value,
       });
     });
   }

--- a/server/src/reviews/reviews.exportFunction.ts
+++ b/server/src/reviews/reviews.exportFunction.ts
@@ -1,0 +1,27 @@
+export const processingReview = async (review: any, includeTag: boolean) => {
+  const reviews = [];
+  for (const data of review) {
+    const bookInfo = JSON.parse(data['book_info']);
+    let temp = {
+      id: data['id'],
+      writer: data['user']['nickname'],
+      score: data['score'],
+      summary: data['summary'],
+      like_count: data['like_count'],
+      bookTitle: bookInfo['title'],
+      bookCover: bookInfo['cover'],
+      bookIsbn: data['isbn'],
+      tags: [],
+    };
+    if (includeTag) {
+      temp = {
+        ...temp,
+        tags: data['tags'],
+      };
+    } else {
+      delete temp['tags'];
+    }
+    reviews.push(temp);
+  }
+  return reviews;
+};

--- a/server/src/reviews/reviews.service.ts
+++ b/server/src/reviews/reviews.service.ts
@@ -76,9 +76,10 @@ export class ReviewsService {
           'isPublic',
           'like_count',
           'createdAt',
+          'user',
         ],
         where: { isPublic: 1 },
-        relations: ['tags'],
+        relations: ['tags', 'user'],
         //skip: page === 1 ? 0 : page - 1,
         skip: 0,
         take: 12,
@@ -93,6 +94,10 @@ export class ReviewsService {
           title: bookInfo['title'],
           cover: bookInfo['cover'],
           tags: review['tags'],
+          user: {
+            userId: review['user']['userId'],
+            nickname: review['user']['nickname'],
+          },
         };
         reviews.push(r);
       }
@@ -109,9 +114,10 @@ export class ReviewsService {
           'summary',
           'isPublic',
           'createdAt',
+          'user',
         ],
         where: { isPublic: 1 },
-        relations: ['tags'],
+        relations: ['tags', 'user'],
         //skip: page === 1 ? 0 : page - 1,
         skip: 0,
         take: 12,
@@ -126,6 +132,10 @@ export class ReviewsService {
           title: bookInfo['title'],
           cover: bookInfo['cover'],
           tags: review['tags'],
+          user: {
+            userId: review['user']['userId'],
+            nickname: review['user']['nickname'],
+          },
         };
         reviews.push(r);
       }

--- a/server/src/reviews/reviews.service.ts
+++ b/server/src/reviews/reviews.service.ts
@@ -151,7 +151,6 @@ export class ReviewsService {
   ): Promise<Review> {
     const review = new Review();
     review.text = await uploadReviewHtml(reviewfile);
-    review.coverImg = createReviewDto.coverImg;
     review.book_info = createReviewDto.bookInfo;
     review.score = parseFloat(createReviewDto.score);
     review.isPublic = Boolean(parseInt(createReviewDto.isPublic));

--- a/server/src/reviews/reviews.service.ts
+++ b/server/src/reviews/reviews.service.ts
@@ -47,6 +47,7 @@ export class ReviewsService {
     for (const review of temp[0]) {
       const bookInfo = JSON.parse(review['book_info']);
       const r = {
+        id: review['id'],
         writer: review['user']['nickname'],
         score: review['score'],
         summary: review['summary'],
@@ -86,6 +87,7 @@ export class ReviewsService {
       for (const review of temp[0]) {
         const bookInfo = JSON.parse(review['book_info']);
         const r = {
+          id: review['id'],
           score: review['score'],
           summary: review['summary'],
           title: bookInfo['title'],
@@ -118,6 +120,7 @@ export class ReviewsService {
       for (const review of temp[0]) {
         const bookInfo = JSON.parse(review['book_info']);
         const r = {
+          id: review['id'],
           score: review['score'],
           summary: review['summary'],
           title: bookInfo['title'],

--- a/server/src/reviews/reviews.service.ts
+++ b/server/src/reviews/reviews.service.ts
@@ -7,6 +7,7 @@ import { User } from 'src/entities/user.entity';
 import { Repository } from 'typeorm';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
+import { processingReview } from './reviews.exportFunction';
 import { uploadReviewHtml } from './reviews.multerOptions';
 
 @Injectable()
@@ -43,20 +44,8 @@ export class ReviewsService {
       skip: 0,
       take: 6,
     });
-    const reviews = [];
-    for (const review of temp[0]) {
-      const bookInfo = JSON.parse(review['book_info']);
-      const r = {
-        id: review['id'],
-        writer: review['user']['nickname'],
-        score: review['score'],
-        summary: review['summary'],
-        title: bookInfo['title'],
-        cover: bookInfo['cover'],
-      };
-      reviews.push(r);
-    }
-    return reviews;
+
+    return await processingReview(temp[0], false);
   }
 
   //최신순or인기순으로 리뷰 12개 불러오기
@@ -84,24 +73,7 @@ export class ReviewsService {
         skip: 0,
         take: 12,
       });
-      const reviews = [];
-      for (const review of temp[0]) {
-        const bookInfo = JSON.parse(review['book_info']);
-        const r = {
-          id: review['id'],
-          score: review['score'],
-          summary: review['summary'],
-          title: bookInfo['title'],
-          cover: bookInfo['cover'],
-          tags: review['tags'],
-          user: {
-            userId: review['user']['userId'],
-            nickname: review['user']['nickname'],
-          },
-        };
-        reviews.push(r);
-      }
-      return reviews;
+      return await processingReview(temp[0], true);
     } else if (orderby === 'created') {
       const temp = await this.reviewRepository.findAndCount({
         order: {
@@ -122,24 +94,7 @@ export class ReviewsService {
         skip: 0,
         take: 12,
       });
-      const reviews = [];
-      for (const review of temp[0]) {
-        const bookInfo = JSON.parse(review['book_info']);
-        const r = {
-          id: review['id'],
-          score: review['score'],
-          summary: review['summary'],
-          title: bookInfo['title'],
-          cover: bookInfo['cover'],
-          tags: review['tags'],
-          user: {
-            userId: review['user']['userId'],
-            nickname: review['user']['nickname'],
-          },
-        };
-        reviews.push(r);
-      }
-      return reviews;
+      return await processingReview(temp[0], true);
     }
   }
 

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -145,4 +145,15 @@ export class UsersController {
     const likes = await this.usersService.getMyLikes(nickname);
     return likes;
   }
+
+  //nickname으로 유저 서치
+  @Get('/search/:nickname')
+  getUserByNick(@Param('nickname') nickname: string, @Res() res) {
+    return this.usersService.getUserByNickname(nickname).then((value) => {
+      res.status(HttpStatus.OK).json({
+        success: true,
+        user: value,
+      });
+    });
+  }
 }

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -19,7 +19,6 @@ import { User } from '../entities/user.entity';
 import { AuthUser } from './users.decorator';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { usersmulterOptions } from './users.multerOptions';
-import { throws } from 'assert';
 
 //에러 처리 middleware 생성하기
 

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -19,6 +19,7 @@ import { User } from '../entities/user.entity';
 import { AuthUser } from './users.decorator';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { usersmulterOptions } from './users.multerOptions';
+import { throws } from 'assert';
 
 //에러 처리 middleware 생성하기
 
@@ -144,6 +145,38 @@ export class UsersController {
     console.log('nickname', nickname);
     const likes = await this.usersService.getMyLikes(nickname);
     return likes;
+  }
+
+  //팔로우기능
+  @Post('/follow')
+  async followUser(
+    @AuthUser() data: any,
+    @Body() nickname: string,
+    @Res() res
+  ) {
+    return this.usersService.followUser(data.userId, nickname).then((value) => {
+      res.status(HttpStatus.OK).json({
+        success: true,
+        result: value,
+      });
+    });
+  }
+
+  //언팔로우기능
+  @Post('/unfollow')
+  async unfollowUser(
+    @AuthUser() data: any,
+    @Body() nickname: string,
+    @Res() res
+  ) {
+    return this.usersService
+      .unfollowUser(data.userId, nickname)
+      .then((value) => {
+        res.status(HttpStatus.OK).json({
+          success: true,
+          result: value,
+        });
+      });
   }
 
   //nickname으로 유저 서치

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -119,10 +119,8 @@ export class UsersService {
     if (opponent === undefined) return 'User not found';
 
     I.followings = [opponent];
-    I.countFollowing++;
 
     opponent.followers = [I];
-    opponent.countFollower++;
 
     const result1 = await this.userRepository.save(I);
     const result2 = await this.userRepository.save(opponent);
@@ -152,12 +150,10 @@ export class UsersService {
     I.followings = I.followings.filter((following) => {
       following.id !== opponent.id;
     });
-    I.countFollowing--;
 
     opponent.followers = opponent.followers.filter((follower) => {
       follower.id !== I.id;
     });
-    opponent.countFollower--;
 
     const result1 = await this.userRepository.save(I);
     const result2 = await this.userRepository.save(opponent);

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -95,4 +95,14 @@ export class UsersService {
     const user = await this.userRepository.findOne({ where: { nickname } });
     return this.likeRepository.find({ where: { user: user } });
   }
+
+  //nickname으로 유저 서치
+  async getUserByNickname(nickname: string) {
+    const exUser = await this.userRepository.findOne({ where: { nickname } });
+    if (exUser) {
+      return exUser;
+    } else {
+      return { type: 0, error: 'User not found' };
+    }
+  }
 }

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -125,7 +125,7 @@ export class UsersService {
     const result1 = await this.userRepository.save(I);
     const result2 = await this.userRepository.save(opponent);
 
-    if (result1 && result2) return false;
+    if (result1 && result2) return true;
     else return false;
   }
 


### PR DESCRIPTION
## 개요

[이슈]
- **[GET] api/reviewer/:genres** - genres를 0 or 0,1 or 3,4,5 or 1,4 와 같이 정렬된 형태의 param으로 받으며 같은 장르 값을 가진 유저를 팔로워수 내림차순으로 최대 9명 반환한다.  
- **[GET] api/reviewer/detail/:nickname** - nickname을 param으로 받아 그 유저의 정보, 리뷰 수, 팔로 수, 팔로잉 수와 지금까지 쓴 리뷰List(isPublic=true인것만)를 반환
 
[추가 작업]
- **[GET] api/users/search/:nickname** - nickname을 param으로 받아 유저를 서치합니다.
- **[POST] api/users/follow** - 상대 nickname을 body로 받아 유저를 팔로우.
- **[POST] api/users/unfollow** - 상대 nickname을 body로 받아 유저를 언팔로우. //팔로우와 언팔로우 기능은 계획에 없었는데 reviewer작업에서 팔로우 수 카운트에 헤매다가 작업하게 되었습니다 ㅜ

[수정]
- api/review/home, api/review/:orderby에서 reviewid값도 반환되게 수정.
- **review.entity** coverImg 컬럼 삭제
- 여러 엔티티에서 다대일 관계나 다대다 관계에 onDelete: set null, cascade 등을 추가. app.module의 synchronize도 true로 설정. 
- **book.controller** 알라딘api 검색 컨트롤러가 @ Get('/search/') 이었던 것을 @ Get('/search')로 수정
## 사용 라이브러리

- 추가한 라이브러리가 있는 경우 적어주세요. 이유도 꼭 적어주기!
### ### 
## 스크린샷
![image](https://user-images.githubusercontent.com/56729276/125989397-3a0793d1-3999-4999-9c3f-6f30485c90fa.png)
api/reviewer/0 

![image](https://user-images.githubusercontent.com/56729276/125990620-b701e127-96a7-4832-95a0-b74577a36d6c.png)
api/reviewer/0,1

param을 1,0으로 보내면 "reviewers": [] 과 같이 빈 배열을 반환하게 되니 오름차순으로 정렬해서 보내주세요!

----------------------------

![image](https://user-images.githubusercontent.com/56729276/125992236-5bf6648d-88c0-4c3a-bd4c-19c6b359ae6b.png)
![image](https://user-images.githubusercontent.com/56729276/125992291-c40a753a-e31c-44da-927f-49eb25c3e3ce.png)
api/reviewer/detail/:nickname
리뷰수, 팔로, 팔로잉 수는 따로 추가해서 그런지 맨 뒤에 나오네요

![image](https://user-images.githubusercontent.com/56729276/125999148-b954ecc9-dad5-490b-8aa0-044c695d47c2.png)
존재하지 않는 유저일시 'User not found'

---------------------------

![image](https://user-images.githubusercontent.com/56729276/125993089-e8786cab-151c-43f9-9c8a-f3a5e2c39aee.png)
api/users/search/:existedNickname

![image](https://user-images.githubusercontent.com/56729276/125993128-9bf1c86f-b44d-4cfc-a638-5a8561dc53f0.png)
유저가 존재하지 않을 시 이런 결과를 보냅니다. 일단 임의로 정했습니다


-----------------------------

![image](https://user-images.githubusercontent.com/56729276/125999323-60115676-2315-4a27-89a9-0c526db856af.png)
api/users/follow

![image](https://user-images.githubusercontent.com/56729276/125996541-87e666d1-17ce-4b79-a6a2-c0ca61c95da2.png)
api/users/unfollow

![image](https://user-images.githubusercontent.com/56729276/125999959-9164d721-b135-4876-b452-8783ee9188c8.png)
팔로우나 언팔로우 시 존재하지않는 닉네임의 유저라면 'User not found'


nickname으로 유저를 조회할 때 존재하지 않으면 api들이 결과를 살짝씩 다르게 보내고 있는데 다음 작업시 수정하겠습니다.