### PR TITLE
New search page to book detail issue#96

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -66,7 +66,7 @@ const App: FunctionComponent = () => {
                     component={Auth(SearchPage, null)}
                   />
                   <Route
-                    path="/book/:id"
+                    path="/book/:isbn"
                     exact
                     component={Auth(BookDetailPage, null)}
                   />

--- a/client/src/components/BookDetail/ReviewWriteBtn.tsx
+++ b/client/src/components/BookDetail/ReviewWriteBtn.tsx
@@ -25,12 +25,17 @@ const Button = styled(LineGreenBtn)`
 const ReviewWriteBtn: FunctionComponent = () => {
   const history = useHistory();
   const onClick = () => {
-    async function getAuth() {
-      const response = await auth();
-      if (response.isAuth) history.push('/write');
-      else alert('먼저 로그인 해주세요!');
-    }
     getAuth();
+    async function getAuth() {
+      try {
+        const response = await auth();
+        response.isAuth
+          ? history.push('/write')
+          : alert('먼저 로그인 해주세요!');
+      } catch (e) {
+        console.log(e);
+      }
+    }
   };
   return (
     <Button onClick={onClick}>

--- a/client/src/components/BookDetail/ReviewWriteBtn.tsx
+++ b/client/src/components/BookDetail/ReviewWriteBtn.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { LineGreenBtn } from '../../style/componentStyled';
 import AddIcon from '@material-ui/icons/Add';
 import { useHistory } from 'react-router';
+import { auth } from '../../API/USER_PRIVATE_API/index';
 
 const Button = styled(LineGreenBtn)`
   position: fixed;
@@ -24,10 +25,12 @@ const Button = styled(LineGreenBtn)`
 const ReviewWriteBtn: FunctionComponent = () => {
   const history = useHistory();
   const onClick = () => {
-    // Todo
-    // 로그인 되어있는지 여부 확인해야함
-    // 로그아웃 상태면 페이지 넘어가지 않고 로그인해주세요 alert창
-    history.push('/write');
+    async function getAuth() {
+      const response = await auth();
+      if (response.isAuth) history.push('/write');
+      else alert('먼저 로그인 해주세요!');
+    }
+    getAuth();
   };
   return (
     <Button onClick={onClick}>

--- a/client/src/components/BookDetail/ReviewWriteBtn.tsx
+++ b/client/src/components/BookDetail/ReviewWriteBtn.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { LineGreenBtn } from '../../style/componentStyled';
 import AddIcon from '@material-ui/icons/Add';
+import { useHistory } from 'react-router';
 
 const Button = styled(LineGreenBtn)`
   position: fixed;
@@ -21,8 +22,15 @@ const Button = styled(LineGreenBtn)`
 `;
 
 const ReviewWriteBtn: FunctionComponent = () => {
+  const history = useHistory();
+  const onClick = () => {
+    // Todo
+    // 로그인 되어있는지 여부 확인해야함
+    // 로그아웃 상태면 페이지 넘어가지 않고 로그인해주세요 alert창
+    history.push('/write');
+  };
   return (
-    <Button>
+    <Button onClick={onClick}>
       <AddIcon fontSize="large" />
     </Button>
   );

--- a/client/src/components/LandingPage/BestSeller.tsx
+++ b/client/src/components/LandingPage/BestSeller.tsx
@@ -27,11 +27,18 @@ const BestSeller = () => {
   const [BestSeller, setBestSeller] = useState([]);
 
   useEffect(() => {
+    // 📌 To do
+    // 에러시 화면이나 메시지 만들기
     axios
       .get('api/book/bestseller')
-      .then(({ data: { bestSeller } }) => setBestSeller(bestSeller))
+      .then(({ data: { bestSeller } }) => {
+        console.log(bestSeller);
+        setBestSeller(bestSeller);
+      })
       .catch((err) => console.log(err));
   }, []);
+
+  console.log(BestSeller);
 
   return (
     <Container>
@@ -39,13 +46,8 @@ const BestSeller = () => {
         <h2>이 책은 어때요?</h2>
       </Header>
       <Main>
-        {BestSeller.map(({ title, isbn, coverLargeUrl }) => (
-          <BestSellerBook
-            key={isbn}
-            isbn={isbn}
-            img={coverLargeUrl}
-            title={title}
-          />
+        {BestSeller.map(({ title, isbn, cover }) => (
+          <BestSellerBook key={isbn} isbn={isbn} img={cover} title={title} />
         ))}
       </Main>
     </Container>

--- a/client/src/components/LandingPage/BestSeller.tsx
+++ b/client/src/components/LandingPage/BestSeller.tsx
@@ -6,39 +6,44 @@ import {
   ItemContainer,
 } from '../common/LandingPageCommon';
 import axios from 'axios';
-
-interface Props {
-  img: string;
-  title: string;
-  isbn?: number;
-}
-
-const BestSellerBook = ({ img, title, isbn }: Props) => {
-  return (
-    // 😎 To do : onClick시 isbn params으로 넘겨서 book/:id로 이동
-    <ItemContainer onClick={(e) => console.log(isbn, title)}>
-      <img key={title} src={img}></img>
-      <h3 className="description">{title}</h3>
-    </ItemContainer>
-  );
-};
+import { setBookInfo } from '../../redux/book/action';
+import { useDispatch } from 'react-redux';
+import { bookInfo } from '../../redux/book/action';
+import { useHistory } from 'react-router';
 
 const BestSeller = () => {
-  const [BestSeller, setBestSeller] = useState([]);
+  const [BestSeller, setBestSeller] = useState<any>([]);
+  const dispatch = useDispatch();
+  const history = useHistory();
 
   useEffect(() => {
     // 📌 To do
     // 에러시 화면이나 메시지 만들기
     axios
       .get('api/book/bestseller')
-      .then(({ data: { bestSeller } }) => {
-        console.log(bestSeller);
-        setBestSeller(bestSeller);
-      })
+      .then(({ data: { bestSeller } }) => setBestSeller(bestSeller))
       .catch((err) => console.log(err));
   }, []);
 
-  console.log(BestSeller);
+  const onClick = (index: number) => {
+    const { isbn } = BestSeller[index];
+    dispatch(setBookInfo({ ...BestSeller[index] }));
+    history.push(`book/${isbn}`);
+  };
+
+  interface Props {
+    onClick: () => void;
+    bookInfo: bookInfo;
+  }
+
+  const BestSellerBook = ({ bookInfo, onClick }: Props) => {
+    return (
+      <ItemContainer onClick={() => onClick()}>
+        <img key={bookInfo.title} src={bookInfo.cover}></img>
+        <h3 className="description">{bookInfo.title}</h3>
+      </ItemContainer>
+    );
+  };
 
   return (
     <Container>
@@ -46,8 +51,12 @@ const BestSeller = () => {
         <h2>이 책은 어때요?</h2>
       </Header>
       <Main>
-        {BestSeller.map(({ title, isbn, cover }) => (
-          <BestSellerBook key={isbn} isbn={isbn} img={cover} title={title} />
+        {BestSeller.map((book: any, index: number) => (
+          <BestSellerBook
+            key={index}
+            onClick={() => onClick(index)}
+            bookInfo={book}
+          />
         ))}
       </Main>
     </Container>

--- a/client/src/components/common/BookDetail.tsx
+++ b/client/src/components/common/BookDetail.tsx
@@ -1,33 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
-
-// 📍 Test Api info
-const TEST_BOOK_INFO = {
-  title:
-    '공부하기가 죽기보다 싫을 때 읽는 책 - 지루함을 못 참는 이들을 위한 맞춤형 공부법',
-  link: 'http://www.aladin.co.kr/shop/wproduct.aspx?ItemId=206699988&amp;partner=openAPI&amp;start=api',
-  author: '권혁진 (지은이)',
-  pubDate: '2019-09-10',
-  description:
-    '공부하기 싫은 마음을 이해하고 공감하며 지루하지 않게 공부하는 법을 다룬다. 기존의 공부법 책들처럼 강한 의지를 요구하거나 거짓 꿈을 만들어 동기 부여하기를 바라지 않는다. 공부를 위해 참고 버티라고도 하지 않는다. 그저 있는 그대로의 자기 성향대로 가장 적합한 환경에서 공부할 수 있는 맞춤형 공부법을 제시한다.',
-  isbn: 'K182636267',
-  isbn13: '9791187962755',
-  itemId: 206699988,
-  priceSales: 13500,
-  priceStandard: 15000,
-  mallType: 'BOOK',
-  stockStatus: '',
-  mileage: 750,
-  cover: 'https://image.aladin.co.kr/product/20669/99/cover/k182636267_1.jpg',
-  categoryId: 70223,
-  categoryName: '국내도서>자기계발>창의적사고/두뇌계발',
-  publisher: '다연',
-  salesPoint: 3652,
-  adult: false,
-  fixedPrice: true,
-  customerReviewRank: 9,
-  subInfo: {},
-};
+import { useState, useEffect } from 'react';
+import { BookProps } from '../../pages/BookDetailPage';
 
 const BookDetailContainer = styled.main`
   display: flex;
@@ -48,9 +22,12 @@ const BookDetailContainer = styled.main`
   }
 `;
 
-const BookDetail: FunctionComponent = () => {
+const BookDetail = ({ bookData }: BookProps) => {
+  const [bookInfo, setbookInfo] = useState({ ...bookData });
   const { link, cover, title, author, publisher, pubDate, description } =
-    TEST_BOOK_INFO;
+    bookInfo;
+
+  console.log(bookInfo);
 
   return (
     <BookDetailContainer>

--- a/client/src/components/common/BookDetail.tsx
+++ b/client/src/components/common/BookDetail.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
-import { useState, useEffect } from 'react';
-import { BookProps } from '../../pages/BookDetailPage';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../redux/rootReducer';
 
 const BookDetailContainer = styled.main`
   display: flex;
@@ -22,28 +22,28 @@ const BookDetailContainer = styled.main`
   }
 `;
 
-const BookDetail = ({ bookData }: BookProps) => {
-  const [bookInfo, setbookInfo] = useState({ ...bookData });
-  const { link, cover, title, author, publisher, pubDate, description } =
-    bookInfo;
-
-  console.log(bookInfo);
+const BookDetail: FunctionComponent = () => {
+  const { bookInfo } = useSelector((state: RootState) => state.book);
 
   return (
     <BookDetailContainer>
-      <a href={link} target="blank">
-        <img className="bookCover" src={cover} alt={cover} />
+      <a href={bookInfo?.link} target="blank">
+        <img
+          className="bookCover"
+          src={bookInfo?.cover}
+          alt={bookInfo?.cover}
+        />
       </a>
       <div className="detailContainer">
-        <h1>{title}</h1>
+        <h1>{bookInfo?.title}</h1>
         <hr />
         <h2>
-          <span>{author}</span>
+          <span>{bookInfo?.author}</span>
           {' | '}
-          <span>{publisher}</span>
+          <span>{bookInfo?.publisher}</span>
         </h2>
-        <h3>{pubDate}</h3>
-        <h3>{description}</h3>
+        <h3>{bookInfo?.pubDate}</h3>
+        <h3>{bookInfo?.description}</h3>
       </div>
     </BookDetailContainer>
   );

--- a/client/src/components/common/BookInfo.tsx
+++ b/client/src/components/common/BookInfo.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 
 const Container = styled.div`
   width: 100%;
+  cursor: pointer;
+
   h2 {
     margin-top: 0.4rem;
     margin-bottom: 0;
@@ -38,11 +40,12 @@ interface IProps {
   imgUrl: string;
   title: string;
   author: string;
+  onClick: () => void;
 }
 
-const BookInfo = ({ imgUrl, title, author }: IProps) => {
+const BookInfo = ({ imgUrl, title, author, onClick }: IProps) => {
   return (
-    <Container>
+    <Container onClick={onClick}>
       <ImgArea>
         <img src={imgUrl} />
       </ImgArea>

--- a/client/src/pages/BookDetailPage/index.tsx
+++ b/client/src/pages/BookDetailPage/index.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react';
 import BookDetail from '../../components/common/BookDetail';
 import BookReview from '../../components/BookDetail/BookReview';
 import ReviewWriteBtn from '../../components/BookDetail/ReviewWriteBtn';
-import { useLocation } from 'react-router';
+import { useHistory, useLocation } from 'react-router';
 
 import styled from 'styled-components';
 
@@ -11,13 +11,23 @@ const Container = styled.div`
   min-height: 100vh;
 `;
 
+export interface BookProps {
+  isbn?: string;
+  bookData?: any;
+}
+
 const BookDetailPage: FunctionComponent = () => {
-  const location = useLocation();
-  console.log(location);
+  const location = useLocation<BookProps>();
+  const { bookData } = location.state;
+  console.log(bookData);
+
+  // Todo
+  // BookDetail에 넘겨주기
+  // BookDetail은 reviewWrite에서도 쓰이니까 state로 상태관리 하면 될듯
 
   return (
     <Container>
-      <BookDetail />
+      <BookDetail bookData={bookData} />
       <h1>REVIEW</h1>
       <BookReview />
       <ReviewWriteBtn />

--- a/client/src/pages/BookDetailPage/index.tsx
+++ b/client/src/pages/BookDetailPage/index.tsx
@@ -11,23 +11,14 @@ const Container = styled.div`
   min-height: 100vh;
 `;
 
-export interface BookProps {
-  isbn?: string;
-  bookData?: any;
-}
-
 const BookDetailPage: FunctionComponent = () => {
-  const location = useLocation<BookProps>();
-  const { bookData } = location.state;
-  console.log(bookData);
-
+  const location = useLocation();
+  console.log(location);
   // Todo
-  // BookDetail에 넘겨주기
-  // BookDetail은 reviewWrite에서도 쓰이니까 state로 상태관리 하면 될듯
-
+  // BookReview 컴포넌트에서 최신순 or 인기순 클릭시 백에 isbn 데이터 넘겨야 함
   return (
     <Container>
-      <BookDetail bookData={bookData} />
+      <BookDetail />
       <h1>REVIEW</h1>
       <BookReview />
       <ReviewWriteBtn />

--- a/client/src/pages/BookDetailPage/index.tsx
+++ b/client/src/pages/BookDetailPage/index.tsx
@@ -14,7 +14,7 @@ const Container = styled.div`
 const BookDetailPage: FunctionComponent = () => {
   const location = useLocation();
   console.log(location);
-  // Todo
+  // 📌 Todo
   // BookReview 컴포넌트에서 최신순 or 인기순 클릭시 백에 isbn 데이터 넘겨야 함
   return (
     <Container>

--- a/client/src/pages/BookDetailPage/index.tsx
+++ b/client/src/pages/BookDetailPage/index.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react';
 import BookDetail from '../../components/common/BookDetail';
 import BookReview from '../../components/BookDetail/BookReview';
 import ReviewWriteBtn from '../../components/BookDetail/ReviewWriteBtn';
+import { useLocation } from 'react-router';
 
 import styled from 'styled-components';
 
@@ -11,6 +12,9 @@ const Container = styled.div`
 `;
 
 const BookDetailPage: FunctionComponent = () => {
+  const location = useLocation();
+  console.log(location);
+
   return (
     <Container>
       <BookDetail />

--- a/client/src/pages/SearchPage/index.tsx
+++ b/client/src/pages/SearchPage/index.tsx
@@ -13,6 +13,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Alert from '@material-ui/lab/Alert';
 import { fetchApi } from '../../redux/search/action';
+import { setBookInfo } from '../../redux/book/action';
 
 const Container = styled.div`
   margin: 2rem;
@@ -73,19 +74,36 @@ const SearchPage: FunctionComponent = () => {
     };
   }, [item]);
 
-  console.log(searchResult);
-
   const onClick = (index: number) => {
-    let isbn;
-    let bookData;
+    const booksInfo = [...(searchResult as Array<any>)];
 
-    getBookInfo();
+    // bookInfo에서 필요한 정보만 추출
+    const {
+      link,
+      cover,
+      title,
+      author,
+      publisher,
+      pubDate,
+      description,
+      isbn,
+    } = booksInfo[index];
 
-    function getBookInfo() {
-      const booksInfo = [...(searchResult as Array<any>)];
-      isbn = booksInfo[index].isbn;
-      bookData = booksInfo[index];
-    }
+    const bookData = {
+      link,
+      cover,
+      title,
+      author,
+      publisher,
+      pubDate,
+      description,
+      isbn,
+    };
+
+    console.log(bookData);
+
+    // To do : 해당 책 정보를 store에 dispatch
+    dispatch(setBookInfo(bookData));
 
     history.push({
       pathname: `book/${isbn}`,

--- a/client/src/pages/SearchPage/index.tsx
+++ b/client/src/pages/SearchPage/index.tsx
@@ -77,7 +77,7 @@ const SearchPage: FunctionComponent = () => {
   const onClick = (index: number) => {
     const booksInfo = [...(searchResult as Array<any>)];
 
-    // bookInfo에서 필요한 정보만 추출
+    // bookInfo에서 필요한 속성만 추출
     const {
       link,
       cover,
@@ -100,15 +100,10 @@ const SearchPage: FunctionComponent = () => {
       isbn,
     };
 
-    console.log(bookData);
-
     // To do : 해당 책 정보를 store에 dispatch
     dispatch(setBookInfo(bookData));
 
-    history.push({
-      pathname: `book/${isbn}`,
-      state: { isbn, bookData },
-    });
+    history.push(`book/${isbn}`);
   };
 
   const Header = () => {

--- a/client/src/pages/SearchPage/index.tsx
+++ b/client/src/pages/SearchPage/index.tsx
@@ -9,11 +9,10 @@ import Person from '../../components/PeopleComponent/Person';
 import BookInfo from '../../components/common/BookInfo';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../redux/rootReducer';
-import { useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Alert from '@material-ui/lab/Alert';
 import { fetchApi } from '../../redux/search/action';
-import useCheck from '../../hooks/useCheck';
 
 const Container = styled.div`
   margin: 2rem;
@@ -41,6 +40,7 @@ const TempContainer = styled.div`
 
 const SearchPage: FunctionComponent = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
 
   const [typeA, setTypeA] = useState<boolean>(true);
   const [typeB, setTypeB] = useState<boolean>(false);
@@ -74,7 +74,19 @@ const SearchPage: FunctionComponent = () => {
   }, [item]);
 
   console.log(searchResult);
-  console.log(msg);
+
+  const onClick = (index: number) => {
+    getBookISBN();
+    function getBookISBN() {
+      const bookInfo = [...(searchResult as Array<any>)];
+      const isbn = bookInfo[index].isbn;
+      const bookData = bookInfo[index];
+      history.push({
+        pathname: `book/${isbn}`,
+        state: { isbn, bookData },
+      });
+    }
+  };
 
   const Header = () => {
     return (
@@ -125,15 +137,7 @@ const SearchPage: FunctionComponent = () => {
       <GridLayout>
         {typeB && !loading ? (
           <>
-            <GridItem>
-              <Person />
-            </GridItem>
-            <GridItem>
-              <Person />
-            </GridItem>
-            <GridItem>
-              <button>더 보기</button>
-            </GridItem>
+            <Person />
           </>
         ) : (
           <>
@@ -142,6 +146,7 @@ const SearchPage: FunctionComponent = () => {
                 return (
                   <GridSmallItem key={index}>
                     <BookInfo
+                      onClick={() => onClick(index)}
                       imgUrl={result.cover}
                       title={result.title}
                       author={result.author}

--- a/client/src/pages/SearchPage/index.tsx
+++ b/client/src/pages/SearchPage/index.tsx
@@ -100,7 +100,7 @@ const SearchPage: FunctionComponent = () => {
       isbn,
     };
 
-    // To do : 해당 책 정보를 store에 dispatch
+    // 해당 책 정보를 store에 dispatch
     dispatch(setBookInfo(bookData));
 
     history.push(`book/${isbn}`);

--- a/client/src/pages/SearchPage/index.tsx
+++ b/client/src/pages/SearchPage/index.tsx
@@ -76,16 +76,21 @@ const SearchPage: FunctionComponent = () => {
   console.log(searchResult);
 
   const onClick = (index: number) => {
-    getBookISBN();
-    function getBookISBN() {
-      const bookInfo = [...(searchResult as Array<any>)];
-      const isbn = bookInfo[index].isbn;
-      const bookData = bookInfo[index];
-      history.push({
-        pathname: `book/${isbn}`,
-        state: { isbn, bookData },
-      });
+    let isbn;
+    let bookData;
+
+    getBookInfo();
+
+    function getBookInfo() {
+      const booksInfo = [...(searchResult as Array<any>)];
+      isbn = booksInfo[index].isbn;
+      bookData = booksInfo[index];
     }
+
+    history.push({
+      pathname: `book/${isbn}`,
+      state: { isbn, bookData },
+    });
   };
 
   const Header = () => {

--- a/client/src/redux/book/action.ts
+++ b/client/src/redux/book/action.ts
@@ -1,6 +1,6 @@
 import { SET_BOOK_INFO } from './book-type';
 
-interface bookInfo {
+export interface bookInfo {
   isbn: string;
   link: string;
   cover: string;
@@ -11,11 +11,7 @@ interface bookInfo {
   description: string;
 }
 
-interface bookProps {
-  bookInfo: bookInfo[];
-}
-
-export const setBookInfo = (bookInfo: bookProps) => {
+export const setBookInfo = (bookInfo: bookInfo) => {
   return {
     type: SET_BOOK_INFO,
     payload: bookInfo,

--- a/client/src/redux/book/action.ts
+++ b/client/src/redux/book/action.ts
@@ -15,9 +15,9 @@ interface bookProps {
   bookInfo: bookInfo[];
 }
 
-export const setBookInfo = (bookProps: bookProps) => {
+export const setBookInfo = (bookInfo: bookProps) => {
   return {
     type: SET_BOOK_INFO,
-    payload: bookProps,
+    payload: bookInfo,
   };
 };

--- a/client/src/redux/book/action.ts
+++ b/client/src/redux/book/action.ts
@@ -1,0 +1,23 @@
+import { SET_BOOK_INFO } from './book-type';
+
+interface bookInfo {
+  isbn: string;
+  link: string;
+  cover: string;
+  title: string;
+  author: string;
+  publisher: string;
+  pubDate: string;
+  description: string;
+}
+
+interface bookProps {
+  bookInfo: bookInfo[];
+}
+
+export const setBookInfo = (bookProps: bookProps) => {
+  return {
+    type: SET_BOOK_INFO,
+    payload: bookProps,
+  };
+};

--- a/client/src/redux/book/book-type.ts
+++ b/client/src/redux/book/book-type.ts
@@ -1,0 +1,1 @@
+export const BOOK_INFO = 'BOOK_INFO' as const;

--- a/client/src/redux/book/book-type.ts
+++ b/client/src/redux/book/book-type.ts
@@ -1,1 +1,1 @@
-export const BOOK_INFO = 'BOOK_INFO' as const;
+export const SET_BOOK_INFO = 'SET_BOOK_INFO' as const;

--- a/client/src/redux/book/reducer.ts
+++ b/client/src/redux/book/reducer.ts
@@ -1,8 +1,8 @@
 import { SET_BOOK_INFO } from './book-type';
-import { bookProps } from './action';
+import { bookInfo } from './action';
 
 export type BookState = {
-  bookInfo: bookProps | null;
+  bookInfo: bookInfo | null;
 };
 
 const INITIAL_STATE = {

--- a/client/src/redux/book/reducer.ts
+++ b/client/src/redux/book/reducer.ts
@@ -1,0 +1,24 @@
+import { SET_BOOK_INFO } from './book-type';
+import { bookProps } from './action';
+
+export type BookState = {
+  bookInfo: bookProps | null;
+};
+
+const INITIAL_STATE = {
+  bookInfo: null,
+};
+
+export default function BookReducer(
+  state: BookState = INITIAL_STATE,
+  action: any
+): BookState {
+  switch (action.type) {
+    case SET_BOOK_INFO:
+      return {
+        bookInfo: action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/client/src/redux/rootReducer.ts
+++ b/client/src/redux/rootReducer.ts
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux';
 import AuthReducer from './user/AuthReducer';
 import SearchReducer from './search/reducer';
+import BookReducer from './book/reducer';
 
 const rootReducer = combineReducers({
   auth: AuthReducer,
   search: SearchReducer,
+  book: BookReducer,
 });
 
 export default rootReducer;

--- a/server/src/book/book.service.ts
+++ b/server/src/book/book.service.ts
@@ -32,7 +32,12 @@ export class BookService {
       processedData[i] = {
         title: response.data.item[i].title,
         isbn: response.data.item[i].isbn,
-        coverLargeUrl: response.data.item[i].coverLargeUrl,
+        cover: response.data.item[i].coverLargeUrl,
+        description: response.data.item[i].description,
+        author: response.data.item[i].author,
+        publisher: response.data.item[i].publisher,
+        pubDate: response.data.item[i].pubDate,
+        link: response.data.item[i].link,
       };
     }
     return processedData;


### PR DESCRIPTION
## 개요

- search 페이지에서 도서 클릭시 book detail 페이지로 넘어가는 작업
- landing 페이지의 베스트셀러 도서 클릭시 book detail 페이지로 넘어가는 작업
- 알라딘 api와 인터파크 api에서 받아오는 데이터 속성명 통일 및 필요한 데이터 추가를 위해 `server/src/book/book.service.ts` 수정
- book redux 작업
 
## 사용 라이브러리

- 없음

## 스크린샷

###  베스트셀러에서 리뷰 쓰는 페이지까지
![bestseller_to_reviewWrite](https://user-images.githubusercontent.com/67622600/126040340-899e4e79-0dcc-4051-8aac-672f41eaad7f.gif)

___

### 서치페이지에서 리뷰 쓰는 페이지까지
![searchPage_to_reviewWrite](https://user-images.githubusercontent.com/67622600/126040364-7fc123cd-6b85-46cf-9f78-0f6a8cd74020.gif)


## 🔥 기타 추가할 사항
- review 버튼 눌렀을 때 로그인 여부 확인하는 로직 필요
