### PR TITLE
Fix review page bug issue#125

### DIFF
--- a/client/src/components/BookDetail/BookReview.tsx
+++ b/client/src/components/BookDetail/BookReview.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
 import { ProfileImg } from '../../style/componentStyled';
 import FavoriteIcon from '@material-ui/icons/Favorite';
-import SmsIcon from '@material-ui/icons/Sms';
 import axios from 'axios';
 import TransferDate from '../../globalFunction/TransferDate';
 import { myProfileImg } from '../../globalFunction/myInfoDefaultValue';
@@ -60,6 +59,10 @@ const Review = styled.div`
     width: 70%;
   }
 
+  .review_contents h3 {
+    color: ${(props) => props.theme.palette.darkgreen};
+  }
+
   .review_comments {
     text-align: right;
   }
@@ -67,11 +70,6 @@ const Review = styled.div`
 
 const LikedIcon = styled(FavoriteIcon)`
   color: red;
-  margin: 0 4px;
-  font-size: 18px;
-`;
-
-const CommentsIcon = styled(SmsIcon)`
   margin: 0 4px;
   font-size: 18px;
 `;
@@ -156,22 +154,14 @@ const BookReview = ({ reviews, isEmptyReviews, isbn }: Props) => {
       <ReviewContainer>
         {isEmptyReviews && (
           <NoResultMsg>
-            아직 작성된 리뷰가 없어요😢 <br /> 첫 리뷰를 작성해주세요!
+            아직 작성된 리뷰가 없어요😢 <br />이 책의 첫 리뷰어가 되어보세요!
           </NoResultMsg>
         )}
         {tabs[0].selected ? (
           <>
             {reviews?.map(
               (
-                {
-                  commentCount,
-                  likeCount,
-                  summary,
-                  writer,
-                  writerProfileImg,
-                  createdAt,
-                  id,
-                },
+                { likeCount, summary, writer, writerProfileImg, createdAt, id },
                 index: number
               ) => (
                 <Review key={index}>
@@ -184,7 +174,7 @@ const BookReview = ({ reviews, isEmptyReviews, isbn }: Props) => {
                   />
                   <div className="review_contents">
                     <h3>
-                      {TransferDate(createdAt)} {writer} 님이 올리신 리뷰입니다.
+                      {TransferDate(createdAt)} {writer} 님이 올리신 리뷰입니다
                     </h3>
                     <h4>
                       {summary}
@@ -194,8 +184,7 @@ const BookReview = ({ reviews, isEmptyReviews, isbn }: Props) => {
                     </h4>
                     <div className="review_comments">
                       <LikedIcon />
-                      {likeCount} <CommentsIcon />
-                      {commentCount}
+                      {likeCount}
                     </div>
                   </div>
                 </Review>
@@ -206,15 +195,7 @@ const BookReview = ({ reviews, isEmptyReviews, isbn }: Props) => {
           <>
             {_reviews?.map(
               (
-                {
-                  commentCount,
-                  likeCount,
-                  summary,
-                  writer,
-                  writerProfileImg,
-                  createdAt,
-                  id,
-                },
+                { likeCount, summary, writer, writerProfileImg, createdAt, id },
                 index: number
               ) => (
                 <Review key={index}>
@@ -237,8 +218,7 @@ const BookReview = ({ reviews, isEmptyReviews, isbn }: Props) => {
                     </h4>
                     <div className="review_comments">
                       <LikedIcon />
-                      {likeCount} <CommentsIcon />
-                      {commentCount}
+                      {likeCount}
                     </div>
                   </div>
                 </Review>

--- a/client/src/components/WriteReviewComponent/WriteEditor.tsx
+++ b/client/src/components/WriteReviewComponent/WriteEditor.tsx
@@ -82,7 +82,7 @@ const WriteEditor = (props: any, ref: any) => {
   };
 
   const setText = (text: string) => {
-    setSummary(text.slice(0, 30));
+    setSummary(text.replace(/(\r\n\t|\n|\r\t)/gm, '').slice(0, 50));
   };
 
   useImperativeHandle(ref, () => ({

--- a/client/src/modules/book/action.ts
+++ b/client/src/modules/book/action.ts
@@ -1,7 +1,7 @@
 import { SET_BOOK_INFO } from './book-type';
 
 export interface bookInfo {
-  isbn: string;
+  isbn13: string;
   link: string;
   cover: string;
   title: string;

--- a/client/src/pages/BookDetailPage/index.tsx
+++ b/client/src/pages/BookDetailPage/index.tsx
@@ -66,7 +66,7 @@ const BookDetailPage: FunctionComponent = () => {
           setIsEmptyReviews(false);
           setReviewError(false);
         } else {
-          setIsEmptyReviews(true); // 지금 여기가 트루로 변하는 상태
+          setIsEmptyReviews(true);
           setReviewError(false);
         }
       } catch (error) {
@@ -76,8 +76,6 @@ const BookDetailPage: FunctionComponent = () => {
     };
     fetchReviews('created');
   }, []);
-
-  console.log(isEmptyReviews);
 
   if (bookError || reviewError) {
     return (

--- a/client/src/pages/SearchPage/index.tsx
+++ b/client/src/pages/SearchPage/index.tsx
@@ -99,34 +99,25 @@ const SearchPage: FunctionComponent = () => {
 
   const onClick = (index: number) => {
     const booksInfo = [...(searchBookResult as Array<any>)];
-
     // bookInfo에서 필요한 속성만 추출
-    const {
-      link,
-      cover,
-      title,
-      author,
-      publisher,
-      pubDate,
-      description,
-      isbn,
-    } = booksInfo[index];
+    const { isbn13 } = booksInfo[index];
 
-    const bookData = {
-      link,
-      cover,
-      title,
-      author,
-      publisher,
-      pubDate,
-      description,
-      isbn,
-    };
+    // const bookData = {
+    //   link,
+    //   cover,
+    //   title,
+    //   author,
+    //   publisher,
+    //   pubDate,
+    //   description,
+    //   isbn13,
+    // };
 
-    // 해당 책 정보를 store에 dispatch
-    dispatch(setBookInfo(bookData));
+    // // 해당 책 정보를 store에 dispatch
+    // dispatch(setBookInfo(bookData));
 
-    history.push(`book/${isbn}`);
+    // bookDetail Page로 이동
+    history.push(`book/${isbn13}`);
   };
 
   const Header = () => {

--- a/server/src/reviews/reviews.service.ts
+++ b/server/src/reviews/reviews.service.ts
@@ -209,7 +209,8 @@ export class ReviewsService {
     //reviewfile,
     createReviewDto: CreateReviewDto
   ): Promise<Review> {
-    const isbn = JSON.parse(createReviewDto.bookInfo).isbn;
+    // 알라딘 bookInfo 기준 isbn13를 isbn으로 사용 (유진 수정, 확인하셨으면 주석 지우셔도 됩니다)
+    const isbn = JSON.parse(createReviewDto.bookInfo).isbn13;
     const review = new Review();
     //review.text = await uploadReviewTxt(reviewfile);
     review.text = createReviewDto.text;


### PR DESCRIPTION
## 개요
- 알라딘 api에서 isbn13과 isbn 둘 중 isbn을 사용하기로 했는데, 인터파크에서는 isbn13을 사용하고 있어서 (isbn이라는 key에 isbn13 value가 들어있었음) 어쩔 수 없이 알라딘도 isbn13을 사용하게 됐습니다. 리뷰를 crud 작업 할 때 도서의 isbn을 저장하는데, 서버단에서도 isbn으로 저장을 해 두길래 `server/src/reviews/reviews.service.ts` 부분을 isbn13으로 바꾸어놨어요. *백엔분*들은 커밋 부분 살펴보시고 또 isbn을 사용하는 곳이 있다면 isbn13으로 바꿔주시면 되겠습니다.
 
## 사용 라이브러리

- 없음

## 스크린샷

![화면 캡처 2021-07-24 191520](https://user-images.githubusercontent.com/67622600/126865429-a2f4be37-1581-4a8f-9540-f3010c1ae6e3.png)

이제 베스트셀러에서 리뷰를 작성해도 리뷰를 잘 읽어옵니다.

