### PR TITLE
Update landing page modify issue#157

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { ScrollToTop } from './components/common/ScrollToTop';
 import Auth from 'hocAuth';
 import { Provider } from 'react-redux';
 import Main from 'layout/Main';
@@ -23,6 +24,7 @@ const App: FunctionComponent = () => {
     <Provider store={store}>
       <Main>
         <BrowserRouter>
+          <ScrollToTop />
           <Header />
           <Switch>
             <>

--- a/client/src/components/LandingPage/BestSeller.tsx
+++ b/client/src/components/LandingPage/BestSeller.tsx
@@ -1,37 +1,34 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   Container,
   Header,
   Main,
   ItemContainer,
 } from '../common/LandingPageCommon';
-import axios from 'axios';
 
-const BestSeller = () => {
-  const [BestSeller, setBestSeller] = useState<any>([]);
-  const [err, setErr] = useState<boolean>(false);
+interface book {
+  author: string;
+  cover: string;
+  description: string;
+  isbn: string;
+  link: string;
+  pubDate: string;
+  publisher: string;
+  title: string;
+}
 
-  useEffect(() => {
-    axios
-      .get('api/book/bestseller')
-      .then(({ data: { bestSeller } }) => setBestSeller(bestSeller))
-      .catch((err) => setErr(true));
-  }, []);
+interface IProps {
+  bestSeller: Array<book>;
+}
 
-  // 📌 To do
-  // 에러시 화면이나 메시지 만들기 => 에러 모음 화면 만드는 것도 고려
-
-  if (err) {
-    return <div> 에러가 발생했습니다. 다시 시도해주세요. </div>;
-  }
-
+const BestSeller = ({ bestSeller }: IProps) => {
   return (
     <Container>
       <Header>
         <h2>이 책은 어때요?</h2>
       </Header>
       <Main>
-        {BestSeller.map((book: any, index: number) => (
+        {bestSeller.map((book: book, index: number) => (
           <ItemContainer to={`book/${book.isbn}`} key={index}>
             <img key={book.title} src={book.cover}></img>
             <h3 className="description">{book.title}</h3>

--- a/client/src/components/LandingPage/BestSeller.tsx
+++ b/client/src/components/LandingPage/BestSeller.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Container,
   Header,
@@ -18,7 +18,7 @@ interface book {
 }
 
 interface IProps {
-  bestSeller: Array<book>;
+  bestSeller: Array<book> | null;
 }
 
 const BestSeller = ({ bestSeller }: IProps) => {
@@ -28,7 +28,7 @@ const BestSeller = ({ bestSeller }: IProps) => {
         <h2>이 책은 어때요?</h2>
       </Header>
       <Main>
-        {bestSeller.map((book: book, index: number) => (
+        {bestSeller?.map((book: book, index: number) => (
           <ItemContainer to={`book/${book.isbn}`} key={index}>
             <img key={book.title} src={book.cover}></img>
             <h3 className="description">{book.title}</h3>

--- a/client/src/components/LandingPage/PopulateReviews.tsx
+++ b/client/src/components/LandingPage/PopulateReviews.tsx
@@ -1,12 +1,21 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { Container, Header, Main } from '../common/LandingPageCommon';
 import SmallReview from '../myPage/SmallReview';
-import GridLayouot from '../common/GridLayout';
+import GridLayout from '../common/GridLayout';
 import GridItem from '../common/GridItem';
 
 const ReviewContainer = styled(Main)``;
+const MoreInfo = styled(Link)`
+  h3 {
+    margin-top: 32px;
+  }
+  h3:hover {
+    color: ${(props) => props.theme.palette.green};
+  }
+`;
+
 const NoReview = styled.div`
   display: flex;
   flex-direction: column;
@@ -50,10 +59,10 @@ const PopulateReview = ({ reviews }: Iprops) => {
     return (
       <Container>
         <Header>
-          <h2>인기 리뷰</h2>
-          <h3>
-            <Link to="/review">더보기</Link>
-          </h3>
+          <h2>지금 핫한🔥 리뷰</h2>
+          <MoreInfo to="/review">
+            <h3>더보기</h3>
+          </MoreInfo>
         </Header>
         <NoReview>
           <h1>아직 리뷰가 없어요😅</h1>
@@ -66,13 +75,13 @@ const PopulateReview = ({ reviews }: Iprops) => {
   return (
     <Container>
       <Header>
-        <h2>인기 리뷰</h2>
-        <h3>
-          <Link to="/review">더보기</Link>
-        </h3>
+        <h2>지금 핫한🔥 리뷰</h2>
+        <MoreInfo to="/review">
+          <h3>더보기</h3>
+        </MoreInfo>
       </Header>
       <ReviewContainer>
-        <GridLayouot>
+        <GridLayout>
           <>
             {reviews?.map((review: review, index: number) => (
               <GridItem key={index}>
@@ -80,7 +89,7 @@ const PopulateReview = ({ reviews }: Iprops) => {
               </GridItem>
             ))}
           </>
-        </GridLayouot>
+        </GridLayout>
       </ReviewContainer>
     </Container>
   );

--- a/client/src/components/LandingPage/PopulateReviews.tsx
+++ b/client/src/components/LandingPage/PopulateReviews.tsx
@@ -46,7 +46,7 @@ interface Iprops {
 }
 
 const PopulateReview = ({ reviews }: Iprops) => {
-  if (!reviews) {
+  if (!reviews?.length) {
     return (
       <Container>
         <Header>

--- a/client/src/components/LandingPage/PopulateReviews.tsx
+++ b/client/src/components/LandingPage/PopulateReviews.tsx
@@ -46,7 +46,7 @@ interface Iprops {
 }
 
 const PopulateReview = ({ reviews }: Iprops) => {
-  if (!reviews?.length) {
+  if (!reviews) {
     return (
       <Container>
         <Header>

--- a/client/src/components/common/Header.tsx
+++ b/client/src/components/common/Header.tsx
@@ -9,6 +9,7 @@ import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import { Link, useLocation } from 'react-router-dom';
 import ProfileModal from './ProfileModal';
 import { modalOpen } from 'modules';
+import ForumIcon from '@material-ui/icons/Forum';
 
 const LogoContainer = styled.img`
   width: 200px;
@@ -48,12 +49,13 @@ const ProfileIcon = styled(AccountCircleIcon)`
 `;
 
 const MenuContainer = styled.ul`
-  width: 100%;
+  width: 80%;
   display: flex;
   height: 2.5rem;
-  box-shadow: 2px 2px rgba(40, 40, 40, 0.08);
   margin: 0;
   padding: 0;
+  border-bottom: 1px solid #ddd;
+
   li {
     list-style: none;
     width: 100%;
@@ -66,7 +68,7 @@ const MenuContainer = styled.ul`
     justify-content: center;
     align-items: center;
     &:hover {
-      background-color: rgba(40, 40, 40, 0.08);
+      color: ${(props) => props.theme.palette.yellow};
       cursor: pointer;
     }
   }

--- a/client/src/components/common/LandingPageCommon.tsx
+++ b/client/src/components/common/LandingPageCommon.tsx
@@ -26,6 +26,7 @@ const Main = styled.div`
   height: 100%;
   width: 100%;
   justify-content: space-around;
+  flex-wrap: wrap;
 `;
 
 const ItemContainer = styled(Link)`
@@ -34,12 +35,13 @@ const ItemContainer = styled(Link)`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: 2100px;
   height: 280px;
   margin: 0 16px;
   cursor: pointer;
 
   img {
+    width: 200px;
+    height: 280px;
     object-fit: cover;
     box-shadow: 0 8px 12px ${(props) => props.theme.palette.gray};
   }
@@ -55,7 +57,8 @@ const ItemContainer = styled(Link)`
     padding: 20px;
     color: rgba(200, 200, 200);
     text-align: center;
-    font-size: 14px;
+    font-size: 15px;
+    color: ${(props) => props.theme.palette.yellow};
   }
 
   &:hover .description {

--- a/client/src/components/common/ScrollToTop.tsx
+++ b/client/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,13 @@
+import React, { FunctionComponent } from 'react';
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};

--- a/client/src/components/myPage/SmallReview.tsx
+++ b/client/src/components/myPage/SmallReview.tsx
@@ -157,9 +157,9 @@ const SmallReview = ({ like, review }: IProps) => {
               <MenuIconBtn reviewid={review.id} />
             )}
             <BookInfo>
-              <a href="">{review.bookTitle.slice(0, MAX_TITLE_LENGTH)}</a>
+              <a>{review.bookTitle.slice(0, MAX_TITLE_LENGTH)}</a>
             </BookInfo>
-            <Rating name="read-only" value={rating} readOnly />
+            <Rating size="small" name="read-only" value={rating} readOnly />
             <TextInfo>
               {like ? (
                 <span>{review.writer}님이 쓰신 리뷰입니다</span>

--- a/client/src/globalFunction/fetchData.ts
+++ b/client/src/globalFunction/fetchData.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+
+interface Props {
+  data: any | null;
+  isLoading: boolean;
+  isError: boolean | null;
+}
+
+const fetchData = async (url: string) => {
+  const state: Props = {
+    data: null,
+    isLoading: true,
+    isError: null,
+  };
+  try {
+    const response = await axios.get(`${url}`);
+    if (response.data) {
+      state.data = response.data;
+      state.isLoading = false;
+      state.isError = false;
+    }
+  } catch (error) {
+    state.data = null;
+    state.isLoading = false;
+    state.isError = true;
+  }
+  return state;
+};
+
+export default fetchData;

--- a/client/src/pages/LandingPage/index.tsx
+++ b/client/src/pages/LandingPage/index.tsx
@@ -1,11 +1,12 @@
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import styled from 'styled-components';
 import axios from 'axios';
-
+import Alert from '@material-ui/lab/Alert';
 import CarouselComponent from '../../components/LandingPage/CarouselComponent';
 import SearchForm from '../../components/common/SearchForm';
 import PopulateReview from '../../components/LandingPage/PopulateReviews';
 import BestSeller from '../../components/LandingPage/BestSeller';
+import { isNullishCoalesce } from 'typescript';
 
 const LandingContainer = styled.main`
   display: flex;
@@ -13,9 +14,6 @@ const LandingContainer = styled.main`
   justify-content: center;
   align-items: center;
 `;
-
-//bestseller랑 populateReview도 여기서 fetch해서 props로 넘겨주는게 낫지만
-//지금은 딱히 문제 될 것 없어 보여서 다른 급한 것 부터 하기
 
 interface review {
   bookCover: string;
@@ -28,9 +26,39 @@ interface review {
   writer: string;
 }
 
+export interface book {
+  author: string;
+  cover: string;
+  description: string;
+  isbn: string;
+  link: string;
+  pubDate: string;
+  publisher: string;
+  title: string;
+}
+
 const LandingPage: FunctionComponent = () => {
   const [reviews, setReviews] = useState<Array<review> | null>(null);
+  const [bestSeller, setBestSeller] = useState<Array<book>>([]);
   const [isError, setError] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const fetchBestSeller = async () => {
+      try {
+        const response = await axios.get('/api/book/bestseller');
+        const {
+          data: { bestSeller },
+        } = response;
+        console.log(bestSeller);
+        setBestSeller(bestSeller);
+        setError(false);
+      } catch (error) {
+        console.log(error);
+        setError(true);
+      }
+    };
+    fetchBestSeller();
+  }, []);
 
   useEffect(() => {
     const fetchReviews = async () => {
@@ -43,8 +71,8 @@ const LandingPage: FunctionComponent = () => {
           setError(false);
           setReviews(reviews);
         }
-      } catch (err) {
-        console.log(err);
+      } catch (error) {
+        console.log(error);
         setError(true);
       }
     };
@@ -55,11 +83,15 @@ const LandingPage: FunctionComponent = () => {
     <LandingContainer>
       <CarouselComponent />
       <SearchForm />
-      <BestSeller />
       {isError ? (
-        <h2>에러가 발생했어요😢 잠시후 다시 시도해주세요</h2>
+        <Alert severity="error">
+          에러가 발생했습니다. 잠시 후 다시 시도해주세요.
+        </Alert>
       ) : (
-        <PopulateReview reviews={reviews} />
+        <>
+          <BestSeller bestSeller={bestSeller} />
+          <PopulateReview reviews={reviews} />
+        </>
       )}
     </LandingContainer>
   );

--- a/client/src/pages/LandingPage/index.tsx
+++ b/client/src/pages/LandingPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState, useEffect } from 'react';
+import React, { FunctionComponent, useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import Alert from '@material-ui/lab/Alert';
 import CarouselComponent from '../../components/LandingPage/CarouselComponent';
@@ -31,33 +31,35 @@ interface IProps {
   isError: boolean | null;
 }
 
+const initialState: IProps = {
+  data: null,
+  isLoading: true,
+  isError: null,
+};
+
 const LandingPage: FunctionComponent = () => {
   const [bestSellerState, setBestSellerState] = useState<IProps>({
-    data: null,
-    isLoading: true,
-    isError: null,
+    ...initialState,
   });
   const [reviewsState, setReviewsState] = useState<IProps>({
-    data: null,
-    isLoading: true,
-    isError: null,
+    ...initialState,
   });
 
   useEffect(() => {
-    fetchData('/api/book/bestseller').then((res) => {
+    fetchData('/api/book/bestseller').then(({ data, isError, isLoading }) => {
       setBestSellerState({
         ...bestSellerState,
-        data: res.data.bestSeller,
-        isError: res.isError,
-        isLoading: res.isLoading,
+        data: data.bestSeller,
+        isError,
+        isLoading,
       });
     });
-    fetchData('/api/review/home').then((res) => {
+    fetchData('/api/review/home').then(({ data, isError, isLoading }) => {
       setReviewsState({
         ...reviewsState,
-        data: res.data.reviews,
-        isError: res.isError,
-        isLoading: res.isLoading,
+        data: data.reviews,
+        isError,
+        isLoading,
       });
     });
   }, []);


### PR DESCRIPTION
## 개요

- 스타일링
- 코드 정리
- 버그는 아닌데 페이지 전환시 그 전 페이지에 있던 위치로 이동하는 이슈 수정 (ex - 이전 페이지에서 스크롤 맨 아래 위치 일 때 클릭했다면 다음 페이지도 그 위치에서 보여지는 현상)
 
## 사용 라이브러리

- 추가한 라이브러리가 있는 경우 적어주세요. 이유도 꼭 적어주기!

## 스크린샷
![수정](https://user-images.githubusercontent.com/67622600/127012002-1e70be5b-addc-47fd-b078-d61e577ab055.gif)
이제 페이지 전환시마다 스크롤 맨 위로 고정됩니다
